### PR TITLE
Fix dependency resolution of generator artifacts

### DIFF
--- a/subprojects/build.gradle
+++ b/subprojects/build.gradle
@@ -36,6 +36,7 @@ task javadoc(type: Javadoc, group: "Documentation") {
 	source subprojects.collect { it.sourceSets.main.allJava }
 	classpath = files(subprojects.collect { it.sourceSets.main.compileClasspath })
 	title = "eTrice Gradle Plugin Javadoc"
+	options.source = '8'
 	options.links "https://docs.oracle.com/javase/8/docs/api/",
 		"https://docs.gradle.org/$gradle.gradleVersion/javadoc/"
 	destinationDir = file("$siteDir/javadoc")

--- a/subprojects/de.protos.etrice.gradle/src/main/java/de/protos/etrice/gradle/ETriceBasePlugin.java
+++ b/subprojects/de.protos.etrice.gradle/src/main/java/de/protos/etrice/gradle/ETriceBasePlugin.java
@@ -29,6 +29,7 @@ import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.file.SourceDirectorySet;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.plugins.BasePlugin;
+import org.gradle.api.plugins.JvmEcosystemPlugin;
 import org.gradle.api.plugins.PluginContainer;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.TaskProvider;
@@ -66,6 +67,7 @@ public class ETriceBasePlugin implements Plugin<Project> {
 		final ObjectFactory objects = project.getObjects();
 		
 		plugins.apply(BasePlugin.class);
+		plugins.apply(JvmEcosystemPlugin.class);
 		plugins.apply(AdhocComponentPlugin.class);
 		
 		dependencies.getAttributesSchema().attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, strategy -> {

--- a/subprojects/de.protos.etrice.gradle/src/main/java/de/protos/etrice/gradle/EtUnitConvertPlugin.java
+++ b/subprojects/de.protos.etrice.gradle/src/main/java/de/protos/etrice/gradle/EtUnitConvertPlugin.java
@@ -12,6 +12,8 @@ import org.gradle.api.attributes.LibraryElements;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.plugins.ExtensionContainer;
+import org.gradle.api.plugins.JvmEcosystemPlugin;
+import org.gradle.api.plugins.PluginContainer;
 import org.gradle.api.tasks.TaskContainer;
 
 /**
@@ -28,11 +30,14 @@ public class EtUnitConvertPlugin implements Plugin<Project> {
 	
 	@Override
 	public void apply(Project project) {
+		PluginContainer plugins = project.getPlugins();
 		ObjectFactory objects = project.getObjects();
 		ConfigurationContainer configurations = project.getConfigurations();
 		DependencyHandler dependencies = project.getDependencies();
 		TaskContainer tasks = project.getTasks();
 		ExtensionContainer extensions = project.getExtensions();
+		
+		plugins.apply(JvmEcosystemPlugin.class);
 		
 		NamedDomainObjectProvider<Configuration> etunit = configurations.register(ETUNIT_CONVERTER_CONFIGURATION_NAME, c -> {
 			c.setCanBeConsumed(false);

--- a/subprojects/de.protos.etrice.gradle/src/test/groovy/de/protos/etrice/gradle/FunctionalTests.groovy
+++ b/subprojects/de.protos.etrice.gradle/src/test/groovy/de/protos/etrice/gradle/FunctionalTests.groovy
@@ -133,7 +133,7 @@ RoomModel lib {
 def appRoomFile = """\
 RoomModel app {
 	import etrice.api.types.boolean
-	ActorClass ATest {
+	ActorClass AApp {
 		Structure {
 			Attribute b : boolean
 			ActorRef aref : lib.ALib
@@ -146,12 +146,12 @@ GradleProjectBuilder.build("etriceMultiProjectTest") {
 	write("lib/build.gradle", libBuildFile)
 	write("lib/model/lib.room", libRoomFile)
 	write("app/build.gradle", appBuildFile)
-	write("app/model/test.room", appRoomFile)
+	write("app/model/app.room", appRoomFile)
 	gradle("build") {
 		assert task(":lib:generateRoom")?.outcome == TaskOutcome.SUCCESS
 		assert task(":app:generateRoom")?.outcome == TaskOutcome.SUCCESS
 		assert exists("lib/build/src-gen/room/lib/ALib.c")
-		assert exists("app/build/src-gen/room/app/ATest.c")
+		assert exists("app/build/src-gen/room/app/AApp.c")
 	}
 }}
 


### PR DESCRIPTION
The Gradle dependency resolution for jvm artifacts requires the jvm-ecosystem plugin.