### PR TITLE
Detach generate task from build lifecycle task

### DIFF
--- a/subprojects/de.protos.etrice.gradle/src/main/java/de/protos/etrice/gradle/ETriceBasePlugin.java
+++ b/subprojects/de.protos.etrice.gradle/src/main/java/de/protos/etrice/gradle/ETriceBasePlugin.java
@@ -9,7 +9,6 @@ import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.NamedDomainObjectProvider;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
-import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.Dependency;
@@ -34,7 +33,6 @@ import org.gradle.api.plugins.PluginContainer;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.bundling.Zip;
-import org.gradle.language.base.plugins.LifecycleBasePlugin;
 
 /**
  * Sets up basic configurations and tasks to generate code from models.
@@ -135,11 +133,10 @@ public class ETriceBasePlugin implements Plugin<Project> {
 			t.getProjects().addAll(project.provider(() -> getEclipseModelpathProjects(modelpath.get())));
 			t.getEclipseProjectDirectory().set(layout.getProjectDirectory());
 		});
-		TaskProvider<Task> generateAll = tasks.register(GENERATE_TASK_NAME, t -> {
-			t.setGroup(LifecycleBasePlugin.BUILD_GROUP);
+		tasks.register(GENERATE_TASK_NAME, t -> {
+			t.setDescription("Executes the generate task for each model source set");
 			t.dependsOn(project.provider(() -> modelSet.stream().map(ms -> ms.getGenerateTask()).collect(Collectors.toList())));
 		});
-		tasks.named(LifecycleBasePlugin.BUILD_TASK_NAME).configure(task -> task.dependsOn(generateAll));
 		
 		configurations.register(MODELPATH_DIR_CONFIGURATION_NAME, c -> {
 			c.setCanBeConsumed(true);

--- a/subprojects/de.protos.etrice.gradle/src/main/java/de/protos/etrice/gradle/ETriceCPlugin.java
+++ b/subprojects/de.protos.etrice.gradle/src/main/java/de/protos/etrice/gradle/ETriceCPlugin.java
@@ -7,8 +7,10 @@ import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.file.ProjectLayout;
+import org.gradle.api.plugins.BasePlugin;
 import org.gradle.api.plugins.ExtensionContainer;
 import org.gradle.api.plugins.PluginContainer;
+import org.gradle.api.tasks.TaskContainer;
 
 /**
  * Sets up a standard eTrice C project.
@@ -20,6 +22,7 @@ public class ETriceCPlugin implements Plugin<Project> {
 		final PluginContainer plugins = project.getPlugins();
 		final ExtensionContainer extensions = project.getExtensions();
 		final ProjectLayout layout = project.getLayout();
+		final TaskContainer tasks = project.getTasks();
 		
 		plugins.apply(ETriceBasePlugin.class);
 		
@@ -30,6 +33,7 @@ public class ETriceCPlugin implements Plugin<Project> {
 				modelSource.getGenerateTask().configure(t -> {
 					t.getModule().set("etrice-c");
 				});
+				tasks.named(BasePlugin.ASSEMBLE_TASK_NAME, t -> t.dependsOn(modelSource.getGenerateTask()));
 			})
 		);
 	}

--- a/subprojects/de.protos.etrice.gradle/src/main/java/de/protos/etrice/gradle/ETriceJavaPlugin.java
+++ b/subprojects/de.protos.etrice.gradle/src/main/java/de/protos/etrice/gradle/ETriceJavaPlugin.java
@@ -6,8 +6,10 @@ import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.file.ProjectLayout;
+import org.gradle.api.plugins.BasePlugin;
 import org.gradle.api.plugins.ExtensionContainer;
 import org.gradle.api.plugins.PluginContainer;
+import org.gradle.api.tasks.TaskContainer;
 
 /**
  * Sets up a standard eTrice Java project.
@@ -19,6 +21,7 @@ public class ETriceJavaPlugin implements Plugin<Project> {
 		final PluginContainer plugins = project.getPlugins();
 		final ExtensionContainer extensions = project.getExtensions();
 		final ProjectLayout layout = project.getLayout();
+		final TaskContainer tasks = project.getTasks();
 		
 		plugins.apply(ETriceBasePlugin.class);
 		
@@ -29,6 +32,7 @@ public class ETriceJavaPlugin implements Plugin<Project> {
 				modelSource.getGenerateTask().configure(t -> {
 					t.getModule().set("etrice-java");
 				});
+				tasks.named(BasePlugin.ASSEMBLE_TASK_NAME, t -> t.dependsOn(modelSource.getGenerateTask()));
 			})
 		);
 	}

--- a/subprojects/de.protos.etrice.gradle/src/test/groovy/de/protos/etrice/gradle/FunctionalTests.groovy
+++ b/subprojects/de.protos.etrice.gradle/src/test/groovy/de/protos/etrice/gradle/FunctionalTests.groovy
@@ -27,7 +27,7 @@ modelSet {
 }"""
 GradleProjectBuilder.build("etriceEmptyProjectTest") {
 	write("build.gradle", buildFile)
-	gradle("build") {
+	gradle("generate") {
 		assert task(":generateTest")?.outcome == TaskOutcome.NO_SOURCE
 	}
 }}


### PR DESCRIPTION
The eTrice base plugin should not attach all generate tasks automatically to the assemble or build lifecycle tasks. This allows to individually attach generate tasks to their suitable lifecycle tasks, e.g. assemble for code generators and build for documentation
generators.