### PR TITLE
Make generated modelpath file platform independent

### DIFF
--- a/subprojects/de.protos.etrice.gradle/src/main/java/de/protos/etrice/gradle/ETriceBasePlugin.java
+++ b/subprojects/de.protos.etrice.gradle/src/main/java/de/protos/etrice/gradle/ETriceBasePlugin.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.nio.file.Path;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 import javax.inject.Inject;
 
@@ -173,8 +174,18 @@ public class ETriceBasePlugin implements Plugin<Project> {
 		return allSrcDirs.getFiles().stream()
 			.map(File::toPath)
 			.filter(path -> path.startsWith(projectPath))
-			.map(path -> projectPath.relativize(path).toString())
+			.map(path -> toPathStringWithForwardSlashes(projectPath.relativize(path)))
 			.collect(Collectors.toList());
+	}
+	
+	/**
+	 * Converts a path to a string that separates path segments by forward slashes.
+	 * 
+	 * @param path the path to convert
+	 * @return the path string with forward slashes
+	 */
+	private static String toPathStringWithForwardSlashes(Path path) {
+		return StreamSupport.stream(path.spliterator(), false).map(Path::toString).collect(Collectors.joining("/"));
 	}
 	
 	/**


### PR DESCRIPTION
The eclipseModelpath task generates modelpath files which contain platform specific separators for the paths of source directories.
Instead we always use forward slashes to separate path segments.