### PR TITLE
Set visibility of configurations to false

### DIFF
--- a/subprojects/de.protos.etrice.gradle/src/main/java/de/protos/etrice/gradle/ETriceBasePlugin.java
+++ b/subprojects/de.protos.etrice.gradle/src/main/java/de/protos/etrice/gradle/ETriceBasePlugin.java
@@ -86,10 +86,12 @@ public class ETriceBasePlugin implements Plugin<Project> {
 		NamedDomainObjectProvider<Configuration> generator = configurations.register(GENERATOR_CONFIGURATION_NAME, c -> {
 			c.setCanBeConsumed(false);
 			c.setCanBeResolved(false);
+			c.setVisible(false);
 		});
 		NamedDomainObjectProvider<Configuration> generatorClasspath = configurations.register(GENERATE_CLASSPATH_CONFIGURATION_NAME, c -> {
 			c.setCanBeConsumed(false);
 			c.setCanBeResolved(true);
+			c.setVisible(false);
 			c.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.class, Usage.JAVA_RUNTIME));
 			c.getAttributes().attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.class, Category.LIBRARY));
 			c.getAttributes().attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements.class, LibraryElements.JAR));
@@ -98,10 +100,12 @@ public class ETriceBasePlugin implements Plugin<Project> {
 		NamedDomainObjectProvider<Configuration> modelpath = configurations.register(MODELPATH_CONFIGURATION_NAME, c -> {
 			c.setCanBeConsumed(false);
 			c.setCanBeResolved(false);
+			c.setVisible(false);
 		});
 		NamedDomainObjectProvider<Configuration> generateModelpath = configurations.register(GENERATE_MODELPATH_CONFIGURATION_NAME, c -> {
 			c.setCanBeConsumed(false);
 			c.setCanBeResolved(true);
+			c.setVisible(false);
 			c.getAttributes().attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements.class, LIBRARY_ELEMENTS_MODEL_DIR));
 			c.extendsFrom(modelpath.get());
 		});
@@ -146,6 +150,7 @@ public class ETriceBasePlugin implements Plugin<Project> {
 		configurations.register(MODELPATH_DIR_CONFIGURATION_NAME, c -> {
 			c.setCanBeConsumed(true);
 			c.setCanBeResolved(false);
+			c.setVisible(false);
 			c.getAttributes().attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements.class, LIBRARY_ELEMENTS_MODEL_DIR));
 			c.extendsFrom(modelpath.get());
 			c.getDependencies().add(dependencies.create(allSrcDirs));
@@ -153,6 +158,8 @@ public class ETriceBasePlugin implements Plugin<Project> {
 		NamedDomainObjectProvider<Configuration> modelpathZip = configurations.register(MODELPATH_ZIP_CONFIGURATION_NAME, c -> {
 			c.setCanBeConsumed(true);
 			c.setCanBeResolved(false);
+			// workaround to prevent auto attachment of model zipping task to archives configuration, see https://github.com/protossoftware/etrice-gradle-plugin/issues/4
+			c.setVisible(false);
 			c.getAttributes().attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements.class, LIBRARY_ELEMENTS_MODEL_ZIP));
 			c.extendsFrom(modelpath.get());
 			c.getOutgoing().artifact(zipModel);

--- a/subprojects/de.protos.etrice.gradle/src/main/java/de/protos/etrice/gradle/EtUnitConvertPlugin.java
+++ b/subprojects/de.protos.etrice.gradle/src/main/java/de/protos/etrice/gradle/EtUnitConvertPlugin.java
@@ -42,12 +42,14 @@ public class EtUnitConvertPlugin implements Plugin<Project> {
 		NamedDomainObjectProvider<Configuration> etunit = configurations.register(ETUNIT_CONVERTER_CONFIGURATION_NAME, c -> {
 			c.setCanBeConsumed(false);
 			c.setCanBeResolved(false);
+			c.setVisible(false);
 			c.defaultDependencies(ds ->	ds.add(dependencies.create(ETUNIT_CONVERTER_DEFAULT_DEPENDENCY)));
 		});
 		
 		NamedDomainObjectProvider<Configuration> etunitClasspath = configurations.register(ETUNIT_CONVERTER_CLASSPATH_CONFIGURATION_NAME, c -> {
 			c.setCanBeConsumed(false);
 			c.setCanBeResolved(true);
+			c.setVisible(false);
 			c.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.class, Usage.JAVA_RUNTIME));
 			c.getAttributes().attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.class, Category.LIBRARY));
 			c.getAttributes().attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements.class, LibraryElements.JAR));

--- a/subprojects/de.protos.etrice.gradle/src/main/java/de/protos/etrice/gradle/ModelLibraryPlugin.java
+++ b/subprojects/de.protos.etrice.gradle/src/main/java/de/protos/etrice/gradle/ModelLibraryPlugin.java
@@ -34,12 +34,14 @@ public class ModelLibraryPlugin implements Plugin<Project> {
 		NamedDomainObjectProvider<Configuration> modelLibrary = configurations.register(MODEL_LIBRARY_CONFIGURATION_NAME, c -> {
 			c.setCanBeConsumed(false);
 			c.setCanBeResolved(false);
+			c.setVisible(false);
 			c.setTransitive(false);
 		});
 		
 		NamedDomainObjectProvider<Configuration> unzipModelSource = configurations.register(UNZIP_MODEL_SOURCE_CONFIGURATION_NAME, c -> {
 			c.setCanBeConsumed(false);
 			c.setCanBeResolved(true);
+			c.setVisible(false);
 			c.setTransitive(false);
 			c.getAttributes().attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements.class, ETriceBasePlugin.LIBRARY_ELEMENTS_MODEL_ZIP));
 			c.extendsFrom(modelLibrary.get());

--- a/subprojects/de.protos.etrice.gradle/src/main/java/de/protos/etrice/gradle/SourceLibraryPlugin.java
+++ b/subprojects/de.protos.etrice.gradle/src/main/java/de/protos/etrice/gradle/SourceLibraryPlugin.java
@@ -32,12 +32,14 @@ public class SourceLibraryPlugin implements Plugin<Project> {
 		NamedDomainObjectProvider<Configuration> sourceLibrary = configurations.register(SOURCE_LIBRARY_CONFIGURATION_NAME, c -> {
 			c.setCanBeConsumed(false);
 			c.setCanBeResolved(false);
+			c.setVisible(false);
 			c.setTransitive(false);
 		});
 		
 		NamedDomainObjectProvider<Configuration> unzipSource = configurations.register(UNZIP_SOURCE_CONFIGURATION_NAME, c -> {
 			c.setCanBeConsumed(false);
 			c.setCanBeResolved(true);
+			c.setVisible(false);
 			c.setTransitive(false);
 			c.getAttributes().attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements.class, LIBRARY_ELEMENTS_SOURCE_ZIP));
 			c.extendsFrom(sourceLibrary.get());

--- a/subprojects/de.protos.etrice.gradle/src/main/java/de/protos/etrice/gradle/SourcePublishPlugin.java
+++ b/subprojects/de.protos.etrice.gradle/src/main/java/de/protos/etrice/gradle/SourcePublishPlugin.java
@@ -43,6 +43,7 @@ public class SourcePublishPlugin implements Plugin<Project> {
 		NamedDomainObjectProvider<Configuration> sourceZip = configurations.register(SOURCE_ZIP_CONFIGURATION_NAME, c -> {
 			c.setCanBeConsumed(true);
 			c.setCanBeResolved(false);
+			c.setVisible(false);
 			c.getAttributes().attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements.class, SourceLibraryPlugin.LIBRARY_ELEMENTS_SOURCE_ZIP));
 			c.getOutgoing().artifact(zipSource);
 		});


### PR DESCRIPTION
Artifacts of visible configurations are attached to the archives configuration and thus are built when executing the assemble task. However, the source and model zipping tasks are only required in the rare case that we intend to publish sources and models. Therefore we set the visibility of all our configurations to false.

Fixes #4