### PR TITLE
Fix use of deprecated Gradle API

### DIFF
--- a/subprojects/de.protos.etrice.gradle/src/main/java/de/protos/etrice/gradle/EtUnitConvertTask.java
+++ b/subprojects/de.protos.etrice.gradle/src/main/java/de/protos/etrice/gradle/EtUnitConvertTask.java
@@ -72,7 +72,7 @@ public class EtUnitConvertTask extends SourceTask {
 			spec.classpath(classpath);
 			spec.args(options.get());
 			spec.args(getSource());
-			spec.setMain(ETUNIT_CONVERTER_MAIN);
+			spec.getMainClass().set(ETUNIT_CONVERTER_MAIN);
 			spec.setIgnoreExitValue(false);
 		});
 	}


### PR DESCRIPTION
The method JavaExecSpec::setMain has been deprecated and is replaced by the property JavaExecSpec::getMainClass.