### PR TITLE
Add workaround to run eTrice with Java 17+

### DIFF
--- a/subprojects/de.protos.etrice.gradle/src/main/java/de/protos/etrice/gradle/GenerateTask.java
+++ b/subprojects/de.protos.etrice.gradle/src/main/java/de/protos/etrice/gradle/GenerateTask.java
@@ -7,6 +7,7 @@ import java.util.Map.Entry;
 
 import javax.inject.Inject;
 
+import org.gradle.api.JavaVersion;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.model.ObjectFactory;
@@ -127,6 +128,13 @@ public class GenerateTask extends SourceTask {
 				// This breaks for example Files.createTempFile and Files.createTempDirectory on Windows.
 				// Therefore, we explicitly forward all environment variables to the worker process here.
 				forkOptions.environment(System.getenv());
+				// The following JVM flag allows to run older eTrice versions (which use Xtext 2.25) with Java 17+
+				// and silences illegal reflective access warnings that appear since Java 9+.
+				// The issue originates in old versions of guice which was updated in more recent Xtext versions, 
+				// see https://github.com/google/guice/issues/1085.
+				if(JavaVersion.current().isJava9Compatible()) {
+					forkOptions.jvmArgs("--add-opens", "java.base/java.lang=ALL-UNNAMED");
+				}
 			});
 		});
 		queue.submit(GeneratorWorker.class, params -> {


### PR DESCRIPTION
Adds a JVM flag that allows to run older eTrice versions (which use Xtext 2.25) with Java 17+.
The flag is not necessary to run upcoming eTrice versions with a more recent Xtext version.

This problem only appeared with Gradle 8 because the `--add-opens` flag was implicitly added to Gradle workers in previous versions:
<https://docs.gradle.org/current/userguide/upgrading_version_7.html#remove_implicit_add_opens_for_gradle_workers>.